### PR TITLE
perf: cache enum lookups by name

### DIFF
--- a/src/lookups.ts
+++ b/src/lookups.ts
@@ -18,6 +18,17 @@
 import canboat from '../canboat-lookups.json'
 import { Enumeration, BitEnumeration, FieldTypeEnumeration } from './definition'
 
+let enumByName: Map<string, Enumeration> | undefined
+let bitEnumByName: Map<string, BitEnumeration> | undefined
+let fieldTypeEnumByName: Map<string, FieldTypeEnumeration> | undefined
+
+const invalidateEnumCache = () => {
+  enumByName = undefined
+}
+const invalidateBitEnumCache = () => {
+  bitEnumByName = undefined
+}
+
 /**
  * Retrieves the list of available enumerations from the Canboat library.
  *
@@ -36,7 +47,13 @@ export const getEnumerations = (): Enumeration[] => {
  * @category PGN Definition Access
  */
 export const getEnumeration = (enumName: string): Enumeration | undefined => {
-  return getEnumerations().find((e) => e.Name === enumName)
+  if (enumByName === undefined) {
+    enumByName = new Map()
+    for (const e of getEnumerations()) {
+      enumByName.set(e.Name, e)
+    }
+  }
+  return enumByName.get(enumName)
 }
 
 /**
@@ -111,7 +128,13 @@ export const getBitEnumerations = (): BitEnumeration[] => {
 export const getBitEnumeration = (
   enumName: string
 ): BitEnumeration | undefined => {
-  return getBitEnumerations().find((e) => e.Name === enumName)
+  if (bitEnumByName === undefined) {
+    bitEnumByName = new Map()
+    for (const e of getBitEnumerations()) {
+      bitEnumByName.set(e.Name, e)
+    }
+  }
+  return bitEnumByName.get(enumName)
 }
 
 /**
@@ -169,6 +192,7 @@ export const updateLookup = (enumeration: Enumeration) => {
     }
   }
   canboat.LookupEnumerations.push(enumeration as any)
+  invalidateEnumCache()
 }
 
 /**
@@ -180,6 +204,7 @@ export const removeLookup = (enumeration: Enumeration) => {
   )
   if (index !== -1) {
     canboat.LookupEnumerations.splice(index, 1)
+    invalidateEnumCache()
   }
 }
 
@@ -194,6 +219,7 @@ export const updateBitLookup = (enumeration: BitEnumeration) => {
     }
   }
   canboat.LookupBitEnumerations.push(enumeration as any)
+  invalidateBitEnumCache()
 }
 
 /**
@@ -205,6 +231,7 @@ export const removeBitLookup = (enumeration: BitEnumeration) => {
   )
   if (index !== -1) {
     canboat.LookupBitEnumerations.splice(index, 1)
+    invalidateBitEnumCache()
   }
 }
 
@@ -228,7 +255,13 @@ export const getFieldTypeEnumerations = (): FieldTypeEnumeration[] => {
 export const getFieldTypeEnumeration = (
   enumName: string
 ): FieldTypeEnumeration | undefined => {
-  return getFieldTypeEnumerations().find((e) => e.Name === enumName)
+  if (fieldTypeEnumByName === undefined) {
+    fieldTypeEnumByName = new Map()
+    for (const e of getFieldTypeEnumerations()) {
+      fieldTypeEnumByName.set(e.Name, e)
+    }
+  }
+  return fieldTypeEnumByName.get(enumName)
 }
 
 /**


### PR DESCRIPTION
## Summary

`getEnumeration`, `getBitEnumeration`, and `getFieldTypeEnumeration` each did a linear `Array.find` on every call. Build a name→definition `Map` on first call and reuse it; invalidate from `updateLookup`/`removeLookup`/`updateBitLookup`/`removeBitLookup`. Field-type enums have no mutator so no invalidator is needed there.

## Why

PGNs like 127489 (Engine Parameters, Dynamic) trigger one `getEnumeration` per `LOOKUP` field and one `getBitEnumeration` per `BITLOOKUP` bit (16+16 per packet). On busy NMEA2000 networks the repeated linear scans add up, even though `LookupEnumerations` is only ~220 entries.

## Results

Microbench (5 enum names + 3 bit-enum names per iteration, 1M iterations):

| | time |
|---|---|
| Before | ~820 ms |
| After  | ~160 ms |

~5× faster on the lookup itself. End-to-end `canboatjs` parsing of a real 190k-frame capture is unchanged within measurement noise — the lookup was never the dominant cost in the parser — but the cached path benefits any consumer that does many lookups outside the per-frame parse loop (e.g. SignalK plugins resolving enum names).

## Tested

- `npm test` — all 43 tests pass
- `npm run ci-lint` — clean
- Manual sanity check via repl: cache returns same reference across calls, invalidates correctly on `updateLookup`/`removeLookup`, unknown names return `undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved lookup performance via caching to reduce repeated searches.
  * Ensured cache consistency by invalidating cached lookups when underlying data is updated or removed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/ts-pgns/pull/49)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/ts-pgns/pull/49)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->