### PR TITLE
fix: updateBitLookup appends new entries to the bit-enum list

### DIFF
--- a/src/lookups.ts
+++ b/src/lookups.ts
@@ -193,7 +193,7 @@ export const updateBitLookup = (enumeration: BitEnumeration) => {
       return
     }
   }
-  canboat.LookupEnumerations.push(enumeration as any)
+  canboat.LookupBitEnumerations.push(enumeration as any)
 }
 
 /**

--- a/test/lookups.ts
+++ b/test/lookups.ts
@@ -13,18 +13,27 @@ describe('updateBitLookup', () => {
   it('updates an existing bit enumeration in place', () => {
     const before = getBitEnumeration('ENGINE_STATUS_1')
     expect(before).to.exist
-    const originalLength = before!.EnumBitValues.length
+    const originalMaxValue = before!.MaxValue
+    const originalValues = before!.EnumBitValues
 
-    updateBitLookup({
-      Name: 'ENGINE_STATUS_1',
-      MaxValue: 0xffff,
-      EnumBitValues: before!.EnumBitValues
-    } as BitEnumeration)
+    try {
+      updateBitLookup({
+        Name: 'ENGINE_STATUS_1',
+        MaxValue: 0xffff,
+        EnumBitValues: originalValues
+      } as BitEnumeration)
 
-    const after = getBitEnumeration('ENGINE_STATUS_1')
-    expect(after).to.exist
-    expect(after!.MaxValue).to.equal(0xffff)
-    expect(after!.EnumBitValues).to.have.length(originalLength)
+      const after = getBitEnumeration('ENGINE_STATUS_1')
+      expect(after).to.exist
+      expect(after!.MaxValue).to.equal(0xffff)
+      expect(after!.EnumBitValues).to.have.length(originalValues.length)
+    } finally {
+      updateBitLookup({
+        Name: 'ENGINE_STATUS_1',
+        MaxValue: originalMaxValue,
+        EnumBitValues: originalValues
+      } as BitEnumeration)
+    }
   })
 
   it('adds a new bit enumeration into the bit-enum list (not the regular enum list)', () => {

--- a/test/lookups.ts
+++ b/test/lookups.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai'
+import {
+  BitEnumeration,
+  getBitEnumeration,
+  getBitEnumerations,
+  getEnumeration,
+  getEnumerations,
+  removeBitLookup,
+  updateBitLookup
+} from '../dist/index'
+
+describe('updateBitLookup', () => {
+  it('updates an existing bit enumeration in place', () => {
+    const before = getBitEnumeration('ENGINE_STATUS_1')
+    expect(before).to.exist
+    const originalLength = before!.EnumBitValues.length
+
+    updateBitLookup({
+      Name: 'ENGINE_STATUS_1',
+      MaxValue: 0xffff,
+      EnumBitValues: before!.EnumBitValues
+    } as BitEnumeration)
+
+    const after = getBitEnumeration('ENGINE_STATUS_1')
+    expect(after).to.exist
+    expect(after!.MaxValue).to.equal(0xffff)
+    expect(after!.EnumBitValues).to.have.length(originalLength)
+  })
+
+  it('adds a new bit enumeration into the bit-enum list (not the regular enum list)', () => {
+    const name = 'TEST_UPDATE_BIT_LOOKUP_NEW_ENUM'
+    const added: BitEnumeration = {
+      Name: name,
+      MaxValue: 1,
+      EnumBitValues: [{ Bit: 0, Name: 'FlagZero' }]
+    } as BitEnumeration
+
+    try {
+      updateBitLookup(added)
+
+      const fromBit = getBitEnumeration(name)
+      expect(fromBit, 'getBitEnumeration should find the newly added entry').to
+        .exist
+      expect(fromBit!.EnumBitValues).to.have.length(1)
+      expect(fromBit!.EnumBitValues[0].Name).to.equal('FlagZero')
+
+      expect(
+        getBitEnumerations().some((e) => e.Name === name),
+        'getBitEnumerations should include the newly added entry'
+      ).to.be.true
+
+      expect(
+        getEnumeration(name),
+        'a bit enum must not leak into the regular enum lookup'
+      ).to.be.undefined
+      expect(
+        getEnumerations().some((e) => e.Name === name),
+        'a bit enum must not appear in the regular enum list'
+      ).to.be.false
+    } finally {
+      removeBitLookup(added)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`updateBitLookup` pushed new (not-yet-existing) entries into `LookupEnumerations` instead of `LookupBitEnumerations`. The new entry was unreachable through `getBitEnumeration` / `getBitEnumerations` and polluted the regular non-bit enum list. Updating an existing bit enum already worked (it's a separate code path via `Object.assign`); only the append branch was wrong.

Caught by CodeRabbit in #49.

## Fix

One-line change: push into the right array.

## Tests

Added `test/lookups.ts` with two cases:
- `updates an existing bit enumeration in place` — guards the update branch.
- `adds a new bit enumeration into the bit-enum list (not the regular enum list)` — directly exercises the bug. Fails against the unfixed code, passes after the fix.

## Tested

- `npm test` — 45 passing (was 43; +2 new tests)
- `npm run ci-lint` — clean
- `npm run format` — no changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bit-enumeration storage so new and updated bit entries are recorded in the correct lookup registry for accurate queries.

* **Tests**
  * Added tests covering bit-enumeration behavior: in-place updates, new registrations, lookup isolation, and cleanup to prevent test pollution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canboat/ts-pgns/pull/50)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->